### PR TITLE
Feature: expose more namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pom.xml
 classes
 /pod-babashka-buddy
 /pod-babashka-buddy.jar
+/pod-babashka-buddy.build_artifacts.txt

--- a/README.md
+++ b/README.md
@@ -7,11 +7,29 @@ For buddy's documentation, go [here](https://funcool.github.io/buddy-core/latest
 
 Available namespaces:
 
-- `pod.babashka.buddy.hash`
-- `pod.babashka.buddy.mac`
-- `pod.babashka.buddy.nonce`
+- `pod.babashka.buddy.core.hash`
+- `pod.babashka.buddy.core.mac`
+- `pod.babashka.buddy.core.nonce`
+- `pod.babashka.buddy.core.kdf`
+- `pod.babashka.buddy.sign.jwe`
 
 If you are missing functionality, please create an issue.
+
+### KDF
+
+Note that `pod.babashka.buddy.core.kdf` deviates from buddy's documented API
+because the `buddy.core.kdf/engine` fn returns an instance of
+`org.bouncycastle.crypto.generators.HKDFBytesGenerator` which can't be
+serialized back to the pod client.
+
+Instead we wrap engine results in a call to `buddy.core.kdf/get-bytes` and
+return the byte array.
+
+The fn that does this is named `pod.babashka.buddy.core.kdf/get-bytes-from-engine`
+and that is all that this pod exposes from that namespace.
+
+You call it with a map just like `engine`, but you need to add a `:length` key
+that gets passed to `buddy.core.kdf/get-bytes`.
 
 ## Example
 
@@ -21,9 +39,9 @@ If you are missing functionality, please create an issue.
 (pods/load-pod 'org.babashka/buddy "0.0.1")
 
 (require '[clojure.string :as str]
-         '[pod.babashka.buddy.codecs :as codecs]
-         '[pod.babashka.buddy.mac :as mac]
-         '[pod.babashka.buddy.nonce :as nonce])
+         '[pod.babashka.buddy.core.codecs :as codecs]
+         '[pod.babashka.buddy.core.mac :as mac]
+         '[pod.babashka.buddy.core.nonce :as nonce])
 
 (def hash-algorithm :hmac+sha256)
 (def secret (nonce/random-bytes 64))

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ serialized back to the pod client.
 Instead we wrap engine results in a call to `buddy.core.kdf/get-bytes` and
 return the byte array.
 
-The fn that does this is named `pod.babashka.buddy.core.kdf/get-bytes-from-engine`
+The fn that does this is named `pod.babashka.buddy.core.kdf/get-engine-bytes`
 and that is all that this pod exposes from that namespace.
 
 You call it with a map just like `engine`, but you need to add a `:length` key

--- a/deps.edn
+++ b/deps.edn
@@ -1,15 +1,16 @@
-{:deps {com.cognitect/transit-clj {:mvn/version "1.0.324"}
-        buddy/buddy-core {:mvn/version "1.9.0"}
-        nrepl/bencode {:mvn/version "1.1.0"}
-        babashka/pods {:git/url "https://github.com/babashka/pods"
-                       :sha "22f200ef3006da90971e3bafa794985918b65fea"}}
+{:deps    {com.cognitect/transit-clj {:mvn/version "1.0.324"}
+           buddy/buddy-core          {:mvn/version "1.10.413"}
+           buddy/buddy-sign          {:mvn/version "3.4.1"}
+           nrepl/bencode             {:mvn/version "1.1.0"}
+           babashka/pods             {:git/url "https://github.com/babashka/pods"
+                                      :sha     "22f200ef3006da90971e3bafa794985918b65fea"}}
  :aliases {:uberjar
            {:replace-deps ; tool usage is new in 2.x
             {seancorfield/depstar {:mvn/version "2.0.165"}}
             :ns-default hf.depstar
-            :exec-fn uberjar
-            :exec-args {:jar pod-babashka-buddy.jar
-                        :compile-ns [pod.babashka.buddy]
-                        :aliases [:native]}}
-           :native {:jvm-opts ["-Dclojure.compiler.direct-linking=true"]
-                    :extra-deps {org.clojure/clojure {:mvn/version "1.10.2-rc1"}}}}}
+            :exec-fn    uberjar
+            :exec-args  {:jar        pod-babashka-buddy.jar
+                         :compile-ns [pod.babashka.buddy]
+                         :aliases    [:native]}}
+           :native {:jvm-opts   ["-Dclojure.compiler.direct-linking=true"]
+                    :extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}}}

--- a/script/compile
+++ b/script/compile
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [ -z "$GRAALVM_HOME" ]; then
-    echo "Please set $GRAALVM_HOME"
+    echo "Please set GRAALVM_HOME"
     exit 1
 fi
 

--- a/src/pod/babashka/buddy.clj
+++ b/src/pod/babashka/buddy.clj
@@ -77,7 +77,7 @@
     'str->bytes codecs/str->bytes
     'to-bytes codecs/to-bytes}
    :core/kdf
-   {'get-bytes-from-engine kdf/get-bytes-from-engine}
+   {'get-engine-bytes kdf/get-engine-bytes}
    :sign/jwe
    {'aead-decrypt jwe/aead-decrypt
     'aead-encrypt jwe/aead-encrypt

--- a/src/pod/babashka/buddy/kdf.clj
+++ b/src/pod/babashka/buddy/kdf.clj
@@ -1,7 +1,10 @@
 (ns pod.babashka.buddy.kdf
   (:require [buddy.core.kdf :as kdf]))
 
-(defn get-bytes-from-engine
+(defn get-engine-bytes
+  "buddy.core.kdf/enging composed with buddy.core.kdf/get-bytes.
+  Takes the same map argument as buddy.core.kdf/engine plus a :length key for
+  the get-bytes argument."
   [{:keys [length] :as params}]
   (-> (kdf/engine params)
       (kdf/get-bytes length)))

--- a/src/pod/babashka/buddy/kdf.clj
+++ b/src/pod/babashka/buddy/kdf.clj
@@ -1,0 +1,7 @@
+(ns pod.babashka.buddy.kdf
+  (:require [buddy.core.kdf :as kdf]))
+
+(defn get-bytes-from-engine
+  [{:keys [length] :as params}]
+  (-> (kdf/engine params)
+      (kdf/get-bytes length)))

--- a/test.clj
+++ b/test.clj
@@ -33,8 +33,8 @@
 
 (require '[pod.babashka.buddy.core.kdf :as kdf])
 
-(let [key-bytes (kdf/get-bytes-from-engine {:alg :hkdf+sha256 :key "supersecret" :salt "sea"
-                                            :info "babashka rocks!" :length 32})
+(let [key-bytes (kdf/get-engine-bytes {:alg :hkdf+sha256 :key "supersecret" :salt "sea"
+                                       :info "babashka rocks!" :length 32})
       key-hex (codecs/bytes->hex key-bytes)]
   (assert (= "5189451aed99c4acf6c3573f5eec223a13ab0840bb0138c4080ab87bdf7d0ebc"
              key-hex))

--- a/test.clj
+++ b/test.clj
@@ -6,15 +6,15 @@
   (pods/load-pod "./pod-babashka-buddy")
   (pods/load-pod ["clojure" "-M" "-m" "pod.babashka.buddy"]))
 
-(require '[pod.babashka.buddy.hash :as h])
+(require '[pod.babashka.buddy.core.hash :as h])
 
 (prn (h/sha256 "foo"))
 
-(require '[pod.babashka.buddy.mac :as mac])
+(require '[pod.babashka.buddy.core.mac :as mac])
 
 (prn (mac/hash "foo bar" {:key "mysecretkey" :alg :hmac+sha256}))
 
-(require '[pod.babashka.buddy.nonce :as nonce])
+(require '[pod.babashka.buddy.core.nonce :as nonce])
 
 (prn (nonce/random-bytes 64))
 
@@ -22,7 +22,7 @@
 (def secret (nonce/random-bytes 64))
 
 (require '[clojure.string :as string]
-         '[pod.babashka.buddy.codecs :as codecs])
+         '[pod.babashka.buddy.core.codecs :as codecs])
 
 (let [timestamp (System/currentTimeMillis)
       nonce (nonce/random-bytes 64)
@@ -30,6 +30,27 @@
       payload (pr-str {:nonce nonce-hex :timestamp timestamp})
       signature (codecs/bytes->hex (mac/hash payload {:alg hash-algorithm :key secret}))]
   (prn (string/join "-" [nonce-hex timestamp signature])))
+
+(require '[pod.babashka.buddy.core.kdf :as kdf])
+
+(let [key-bytes (kdf/get-bytes-from-engine {:alg :hkdf+sha256 :key "supersecret" :salt "sea"
+                                            :info "babashka rocks!" :length 32})
+      key-hex (codecs/bytes->hex key-bytes)]
+  (assert (= "5189451aed99c4acf6c3573f5eec223a13ab0840bb0138c4080ab87bdf7d0ebc"
+             key-hex))
+  (prn key-hex))
+
+(require '[pod.babashka.buddy.sign.jwe :as jwe]
+         '[cheshire.core :as json])
+
+(let [jwt {:name "Babashka" :role "Ruler of your shell"}
+      jwt-json (json/encode jwt)
+      key "abcdefghijklmnopqrstuvwxyzABCDEF"
+      jwe (jwe/encrypt jwt-json key)
+      decrypted-jwe (-> jwe (jwe/decrypt key) codecs/bytes->str)]
+  (prn jwe)
+  (prn decrypted-jwe)
+  (assert (= decrypted-jwe jwt-json)))
 
 (when-not (= "executable" (System/getProperty "org.graalvm.nativeimage.kind"))
   (shutdown-agents)


### PR DESCRIPTION
Exposes a couple more namespaces I need in a work project.

I also added variants of the existing namespaces that include the `core` component of the buddy namespaces because one of the namespaces I'm exposing lives in a different (`sign`) namespace. Let me know if you'd like me to handle that differently. I figured it would be good to preserve backwards compatibility.

I added some tests for the new namespaces as well.