### PR TITLE
Fix CI build for "linux" job

### DIFF
--- a/script/setup-musl
+++ b/script/setup-musl
@@ -40,4 +40,6 @@ cd ..
 # Install libz.a in the correct place so ldd can find it
 install -Dm644 "/usr/local/lib/libz.a" "/usr/lib/$arch-linux-musl/libz.a"
 
-ln -s /usr/bin/musl-gcc /usr/bin/x86_64-linux-musl-gcc
+# Only symlink musl-gcc if the destination file doesn't exist. Otherwise
+# the command fails and the CI job fails.
+[[ -e /usr/bin/x86_64-linux-musl-gcc ]] || ln -s /usr/bin/musl-gcc /usr/bin/x86_64-linux-musl-gcc


### PR DESCRIPTION
It seems the cimg/clojure:1.11.1-openjdk-17.0 Docker image used in the "linux" job has been upgraded from Ubuntu 20.04 to Ubuntu 22.04. And installing the "musl-tools" package and its dependencies already places a file at /usr/bin/x86_64-linux-musl-gcc

That makes the last line of scripts/setup-musl to fail with the error

  ln: failed to create symbolic link '/usr/bin/x86_64-linux-musl-gcc': File exists

And aborts the "linux" job.

Thus we need to check if the file exists and, only if it doesn't, then make the symbolic link.