### PR TITLE
Add support for buddy.core.crypto

### DIFF
--- a/script/setup-musl
+++ b/script/setup-musl
@@ -40,4 +40,6 @@ cd ..
 # Install libz.a in the correct place so ldd can find it
 install -Dm644 "/usr/local/lib/libz.a" "/usr/lib/$arch-linux-musl/libz.a"
 
-ln -s /usr/bin/musl-gcc /usr/bin/x86_64-linux-musl-gcc
+# Only symlink musl-gcc if the destination file doesn't exist. Otherwise
+# the command fails and the CI job fails.
+[[ -e /usr/bin/x86_64-linux-musl-gcc ]] || ln -s /usr/bin/musl-gcc /usr/bin/x86_64-linux-musl-gcc

--- a/src/pod/babashka/buddy.clj
+++ b/src/pod/babashka/buddy.clj
@@ -5,6 +5,7 @@
             [buddy.core.hash :as hash]
             [buddy.core.mac :as mac]
             [buddy.core.nonce :as nonce]
+            [pod.babashka.buddy.crypto :as crypto]
             [pod.babashka.buddy.kdf :as kdf]
             [pod.babashka.buddy.jws :as pjws]
             [pod.babashka.buddy.jwt :as jwt]
@@ -94,6 +95,11 @@
     'to-bytes codecs/to-bytes
     'b64->bytes codecs/b64->bytes
     'b64u->bytes codecs/b64u->bytes}
+   :core/crypto
+   {'block-cipher-encrypt crypto/block-cipher-encrypt
+    'block-cipher-decrypt crypto/block-cipher-decrypt
+    'stream-cipher-encrypt crypto/stream-cipher-encrypt
+    'stream-cipher-decrypt crypto/stream-cipher-decrypt}
    :core/kdf
    {'get-engine-bytes kdf/get-engine-bytes}
    :sign/jwe
@@ -138,6 +144,8 @@
    (:core/codecs nses)
    'pod.babashka.buddy.core.codecs
    (:core/codecs nses)
+   'pod.babashka.buddy.core.crypto
+   (:core/crypto nses)
    'pod.babashka.buddy.core.kdf
    (:core/kdf nses)
    'pod.babashka.buddy.sign.jwe
@@ -198,6 +206,10 @@
                    :vars ~(mapv (fn [[k _]]
                                   {:name k})
                                 (get lookup* 'pod.babashka.buddy.core.codecs))}
+                  {:name pod.babashka.buddy.core.crypto
+                   :vars ~(mapv (fn [[k _]]
+                                  {:name k})
+                                (get lookup* 'pod.babashka.buddy.core.crypto))}
                   {:name pod.babashka.buddy.core.kdf
                    :vars ~(mapv (fn [[k _]]
                                   {:name k})

--- a/src/pod/babashka/buddy/crypto.clj
+++ b/src/pod/babashka/buddy/crypto.clj
@@ -1,0 +1,42 @@
+(ns pod.babashka.buddy.crypto
+  (:require [buddy.core.crypto :as crypto]))
+
+(defn block-cipher-encrypt
+  "Same as buddy.core.crypto/encrypt"
+  (^bytes [input key iv]
+   (block-cipher-encrypt input key iv nil))
+  (^bytes [input key iv options]
+   (crypto/encrypt input key iv options)))
+
+(defn block-cipher-decrypt
+  "Same as buddy.core.crypto/decrypt"
+  (^bytes [input key iv]
+   (block-cipher-decrypt input key iv nil))
+  (^bytes [input key iv options]
+   (crypto/decrypt input key iv options)))
+
+(defn stream-cipher-encrypt
+  "buddy.core.crypto/stream-cipher composed with buddy.core.crypto/init!
+  and buddy.core.crypto/process-bytes!.
+
+  `alg` must be a valid algorithm for buddy.core.crypto/stream-cipher.
+  `key` and `iv` must be valid values for the selected `alg`"
+  ^bytes
+  [input key iv alg]
+  (let [engine (-> (crypto/stream-cipher alg)
+                   (crypto/init! {:key key :iv iv :op :encrypt}))]
+    (crypto/process-bytes! engine input)))
+
+(defn stream-cipher-decrypt
+  "buddy.core.crypto/stream-cipher composed with buddy.core.crypto/init!
+  and buddy.core.crypto/process-bytes!
+
+  `alg` must be a valid algorithm for buddy.core.crypto/stream-cipher.
+  `key` and `iv` must be valid values for the selected `alg`"
+  ^bytes
+  [input key iv alg]
+  (let [engine (-> (crypto/stream-cipher alg)
+                   (crypto/init! {:key key :iv iv :op :decrypt}))]
+    (crypto/process-bytes! engine input)))
+
+


### PR DESCRIPTION
**Notice**: This pull request includes the changes of pull request #9 , as I needed to fix the CI build for the "linux" job. Otherwise CircleCI failed the build for this commit, even if the code of the commit is perfectly fine. So you may want to merge PR #9, and then this one.

As the commit message says, add support for buddy.crypto.core. I'm aware of PR #8, but the changes proposed in that patch cannot work. It exposes the original buddy.core.crypto functions. And some of them return instances of BouncyCastle Java classes that cannot be serialized back to the pod client.

So I've taken the same approach that pod.babashka.buddy.kdf has taken for `get-engine-bytes`: compose the problematic functions together inside the pod function, and always return serializable values.

I have also decided to expose just a very small subset of what is available in `buddy.core.crypto` namespace. My rationale for this is that a babahska pod user won't generally need or use the low-level cryptographic primitives, or know what cryptographic constructs may offer which security properties (like non-malleable encryption, nonce or iv misuse, etc). 

So I have restricted the offered functions to those that are sane and secure enough for most people (mostly the authenticated encryption versions for block ciphers), and the only stream cipher offered by buddy.core.crypto (in case someone like me need it, even if it doesn't provide authenticated encryption).

I think this is a good compromise, but YMMV.